### PR TITLE
Update workflow dependencies

### DIFF
--- a/.github/workflows/buildGithubPages.yml
+++ b/.github/workflows/buildGithubPages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -10,12 +11,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
             fetch-depth: 0 # fetch everything so that mkdocs doesn't run into the missing refs problem
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5.3.0
         with:
-          python-version: 3.x
+          python-version: '3.x'
       - run: python .publish/prepareGithubPages.py
-      - run: pip install mkdocs-material=="8.*"
+      - run: pip install mkdocs-material=="9.5.49"
       - run: pip install mkdocs-roamlinks-plugin
       - run: |
          cd .publish
-         mkdocs gh-deploy 
+         mkdocs gh-deploy


### PR DESCRIPTION
Update all actions in this workflow
This pull request includes updates to the GitHub Actions workflow for building GitHub Pages. The most important changes involve updating branch references, dependencies, and version specifications.

Updates to GitHub Actions workflow:

* [`.github/workflows/buildGithubPages.yml`](diffhunk://#diff-91490a381039829409f95a5ca7eb8065707138a009ecf95d21f32ffd8a12feedR6-R18): Added the `main` branch to the list of branches that trigger the workflow.
* [`.github/workflows/buildGithubPages.yml`](diffhunk://#diff-91490a381039829409f95a5ca7eb8065707138a009ecf95d21f32ffd8a12feedR6-R18): Updated `actions/setup-python` from version `v2` to `v5.3.0`.
* [`.github/workflows/buildGithubPages.yml`](diffhunk://#diff-91490a381039829409f95a5ca7eb8065707138a009ecf95d21f32ffd8a12feedR6-R18): Changed the `python-version` specification from `3.x` to `'3.x'` to ensure correct version parsing.
* [`.github/workflows/buildGithubPages.yml`](diffhunk://#diff-91490a381039829409f95a5ca7eb8065707138a009ecf95d21f32ffd8a12feedR6-R18): Updated the `mkdocs-material` package from version `8.*` to `9.5.49`.